### PR TITLE
Add landing, login and register pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,85 +1,31 @@
-<!DOCTYPE html><html lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>CyberRPG Login</title>
-  <link
-  rel="stylesheet"
-  href="https://unpkg.com/xp.css">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cybermmo</title>
+  <link rel="stylesheet" href="https://unpkg.com/xp.css">
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
   <style>
     body {
-      background: url('https://wallpapercave.com/wp/wp4632436.jpg') center center / cover no-repeat;
-      padding: 2rem;
+      background:#000;
+      color:#0ff;
+      font-family:'Press Start 2P', monospace;
+      text-align:center;
+      padding-top:20vh;
     }
-    .window {
-      width: 300px;
-      margin: auto;
+    h1 {
+      margin-bottom:1rem;
     }
-    .content {
-      padding: 1rem;
-    }
-    input[type="text"], input[type="password"] {
-      width: 100%;
-      margin-bottom: 1rem;
-    }
-    .center {
-      text-align: center;
+    .btn {
+      margin:0.5rem;
     }
   </style>
 </head>
 <body>
-  <div class="window">
-    <div class="title-bar">
-      <div class="title-bar-text">Login - CyberRPG</div>
-      <div class="title-bar-controls">
-        <button aria-label="Minimize"></button>
-        <button aria-label="Maximize"></button>
-        <button aria-label="Close"></button>
-      </div>
-    </div>
-    <div class="window-body content">
-      <form id="loginForm">
-        <label for="username">Username</label>
-        <input type="text" id="username" name="username" /><label for="password">Password</label>
-    <input type="password" id="password" name="password" />
-
-    <div class="center">
-      <button type="submit">Login</button>
-    </div>
-    <p class="center">
-      <a href="#" onclick="toggleRegister(); return false;">Register</a>
-    </p>
-  </form>
-</div>
-
-  </div>  <div class="window" id="registerWindow" style="display:none; margin-top: 1rem;">
-    <div class="title-bar">
-      <div class="title-bar-text">Register - CyberRPG</div>
-      <div class="title-bar-controls">
-        <button aria-label="Minimize"></button>
-        <button aria-label="Maximize"></button>
-        <button aria-label="Close" onclick="document.getElementById('registerWindow').style.display='none';"></button>
-      </div>
-    </div>
-    <div class="window-body content">
-      <form id="registerForm">
-        <label for="reg-username">Username</label>
-        <input type="text" id="reg-username" name="reg-username" /><label for="reg-password">Password</label>
-    <input type="password" id="reg-password" name="reg-password" />
-
-    <label for="reg-password-confirm">Confirm Password</label>
-    <input type="password" id="reg-password-confirm" name="reg-password-confirm" />
-
-    <div class="center">
-      <button type="submit">Register</button>
-    </div>
-  </form>
-</div>
-
-  </div>  <script>
-    function toggleRegister() {
-      const regWindow = document.getElementById('registerWindow');
-      regWindow.style.display = regWindow.style.display === 'none' ? 'block' : 'none';
-    }
-  </script></body>
+  <h1>Cybermmo</h1>
+  <p>Welcome to Cybermmo!</p>
+  <a href="login.html"><button class="btn">Login</button></a>
+  <a href="register.html"><button class="btn">Register</button></a>
+</body>
 </html>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Login - Cybermmo</title>
+  <link rel="stylesheet" href="https://unpkg.com/xp.css">
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+  <style>
+    body {
+      background:#000;
+      color:#0ff;
+      font-family:'Press Start 2P', monospace;
+      display:flex;
+      justify-content:center;
+      align-items:center;
+      height:100vh;
+    }
+    .panel {
+      background:#111;
+      border:1px solid #444;
+      padding:1rem;
+      width:300px;
+    }
+    label, input {
+      display:block;
+      width:100%;
+      margin-bottom:0.5rem;
+    }
+    .center {
+      text-align:center;
+    }
+  </style>
+</head>
+<body>
+  <div class="panel">
+    <h2 class="center">Login</h2>
+    <form>
+      <label for="username">Username</label>
+      <input type="text" id="username" name="username">
+      <label for="password">Password</label>
+      <input type="password" id="password" name="password">
+      <div class="center">
+        <button type="submit">Login</button>
+      </div>
+      <p class="center"><a href="register.html">Register</a></p>
+    </form>
+  </div>
+</body>
+</html>

--- a/register.html
+++ b/register.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Register - Cybermmo</title>
+  <link rel="stylesheet" href="https://unpkg.com/xp.css">
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+  <style>
+    body {
+      background:#000;
+      color:#0ff;
+      font-family:'Press Start 2P', monospace;
+      display:flex;
+      justify-content:center;
+      align-items:center;
+      height:100vh;
+    }
+    .panel {
+      background:#111;
+      border:1px solid #444;
+      padding:1rem;
+      width:300px;
+    }
+    label, input {
+      display:block;
+      width:100%;
+      margin-bottom:0.5rem;
+    }
+    .center {
+      text-align:center;
+    }
+  </style>
+</head>
+<body>
+  <div class="panel">
+    <h2 class="center">Register</h2>
+    <form>
+      <label for="username">Username</label>
+      <input type="text" id="username" name="username">
+      <label for="password">Password</label>
+      <input type="password" id="password" name="password">
+      <label for="confirm">Confirm Password</label>
+      <input type="password" id="confirm" name="confirm">
+      <div class="center">
+        <button type="submit">Register</button>
+      </div>
+      <p class="center"><a href="login.html">Login</a></p>
+    </form>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace login interface in `index.html` with a simple landing page that links to login and register
- create `login.html` with a login form
- create `register.html` with a registration form
- apply the design guide's use of dark backgrounds, neon accents and the pixel font

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687d21134f9c8321972387ef747efa20