### PR TITLE
Switch design to use 98.css

### DIFF
--- a/design.md
+++ b/design.md
@@ -9,7 +9,7 @@ This document describes the visual design language for the application. The look
 - Rounded rectangles and beveled edges should be prominent.
 - Apply subtle gradients to create a faux-3D effect.
 - Use small, pixel-art icons for buttons and controls.
-- Use [xp.css](https://github.com/botoxparty/xp.css) to style tabs, buttons, and other controls, but avoid using its window components.
+- Use [98.css](https://github.com/jdan/98.css) to style tabs, buttons, and other controls, but avoid using its window components.
 
 ## Color Palette
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Cybermmo</title>
-  <link rel="stylesheet" href="https://unpkg.com/xp.css">
+  <link rel="stylesheet" href="https://unpkg.com/98.css">
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
   <style>
     body {

--- a/login.html
+++ b/login.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Login - Cybermmo</title>
-  <link rel="stylesheet" href="https://unpkg.com/xp.css">
+  <link rel="stylesheet" href="https://unpkg.com/98.css">
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
   <style>
     body {

--- a/register.html
+++ b/register.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Register - Cybermmo</title>
-  <link rel="stylesheet" href="https://unpkg.com/xp.css">
+  <link rel="stylesheet" href="https://unpkg.com/98.css">
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
   <style>
     body {


### PR DESCRIPTION
## Summary
- update design guide to reference 98.css
- update HTML pages to load 98.css instead of xp.css

## Testing
- `python3 -m py_compile tools/sprite_to_base64.py`

------
https://chatgpt.com/codex/tasks/task_e_687d3ea141a08321a527be6536f4aa1b