### PR TITLE
Switch design to use 98.css

### DIFF
--- a/design.md
+++ b/design.md
@@ -5,11 +5,11 @@ This document describes the visual design language for the application. The look
 ## Layout and Style
 
 - Use dark backgrounds with neon or metallic accents.
-- Opt for pixel fonts or bitmap-style fonts reminiscent of the era.
+- Opt for fonts similar to Windows 98, such as **Tahoma** or **MS Sans Serif**.
 - Rounded rectangles and beveled edges should be prominent.
 - Apply subtle gradients to create a faux-3D effect.
 - Use small, pixel-art icons for buttons and controls.
-- Use [xp.css](https://github.com/botoxparty/xp.css) to style tabs, buttons, and other controls, but avoid using its window components.
+- Use [98.css](https://github.com/jdan/98.css) to style tabs, buttons, and other controls, but avoid using its window components.
 
 ## Color Palette
 
@@ -19,7 +19,7 @@ This document describes the visual design language for the application. The look
 
 ## Typography
 
-- Primary font should mimic a pixel or 8-bit look, such as `Press Start 2P` or similar.
+- Primary font should use a Windows 98-style sans-serif font like `Tahoma` or `MS Sans Serif`.
 - Headers can use a slightly larger size but keep them blocky and minimal.
 
 ## Layout Rules

--- a/index.html
+++ b/index.html
@@ -4,13 +4,13 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Cybermmo</title>
-  <link rel="stylesheet" href="https://unpkg.com/xp.css">
-  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://unpkg.com/98.css">
+  <!-- Use system fonts similar to Windows 98 -->
   <style>
     body {
       background:#000;
       color:#0ff;
-      font-family:'Press Start 2P', monospace;
+      font-family:'Tahoma', 'MS Sans Serif', sans-serif;
       display:flex;
       flex-direction:column;
       justify-content:center;

--- a/login.html
+++ b/login.html
@@ -4,13 +4,13 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Login - Cybermmo</title>
-  <link rel="stylesheet" href="https://unpkg.com/xp.css">
-  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://unpkg.com/98.css">
+  <!-- Use system fonts similar to Windows 98 -->
   <style>
     body {
       background:#000;
       color:#0ff;
-      font-family:'Press Start 2P', monospace;
+      font-family:'Tahoma', 'MS Sans Serif', sans-serif;
       display:flex;
       justify-content:center;
       align-items:center;

--- a/register.html
+++ b/register.html
@@ -4,13 +4,13 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Register - Cybermmo</title>
-  <link rel="stylesheet" href="https://unpkg.com/xp.css">
-  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://unpkg.com/98.css">
+  <!-- Use system fonts similar to Windows 98 -->
   <style>
     body {
       background:#000;
       color:#0ff;
-      font-family:'Press Start 2P', monospace;
+      font-family:'Tahoma', 'MS Sans Serif', sans-serif;
       display:flex;
       justify-content:center;
       align-items:center;


### PR DESCRIPTION
## Summary
- update design guide to reference 98.css
- update HTML pages to load 98.css instead of xp.css
- use system fonts similar to Windows 98 (Tahoma/MS Sans Serif)

## Testing
- `python3 -m py_compile tools/sprite_to_base64.py`


------
https://chatgpt.com/codex/tasks/task_e_687d3ea141a08321a527be6536f4aa1b