### PR TITLE
Switch to Windows 98 font

### DIFF
--- a/design.md
+++ b/design.md
@@ -19,7 +19,7 @@ This document describes the visual design language for the application. The look
 
 ## Typography
 
-- Primary font should mimic a pixel or 8-bit look, such as `Press Start 2P` or similar.
+- Primary font should mimic the pixelated style of Windows 98, such as `"Pixelated MS Sans Serif"` from 98.css.
 - Headers can use a slightly larger size but keep them blocky and minimal.
 
 ## Layout Rules

--- a/index.html
+++ b/index.html
@@ -5,12 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Cybermmo</title>
   <link rel="stylesheet" href="https://unpkg.com/98.css">
-  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
   <style>
     body {
       background:#000;
       color:#0ff;
-      font-family:'Press Start 2P', monospace;
+      font-family:'Pixelated MS Sans Serif', 'MS Sans Serif', Tahoma, sans-serif;
       display:flex;
       flex-direction:column;
       justify-content:center;

--- a/login.html
+++ b/login.html
@@ -5,12 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Login - Cybermmo</title>
   <link rel="stylesheet" href="https://unpkg.com/98.css">
-  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
   <style>
     body {
       background:#000;
       color:#0ff;
-      font-family:'Press Start 2P', monospace;
+      font-family:'Pixelated MS Sans Serif', 'MS Sans Serif', Tahoma, sans-serif;
       display:flex;
       justify-content:center;
       align-items:center;

--- a/register.html
+++ b/register.html
@@ -5,12 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Register - Cybermmo</title>
   <link rel="stylesheet" href="https://unpkg.com/98.css">
-  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
   <style>
     body {
       background:#000;
       color:#0ff;
-      font-family:'Press Start 2P', monospace;
+      font-family:'Pixelated MS Sans Serif', 'MS Sans Serif', Tahoma, sans-serif;
       display:flex;
       justify-content:center;
       align-items:center;


### PR DESCRIPTION
## Summary
- switch font to Pixelated MS Sans Serif for a Windows 98 feel
- update design guide typography section

## Testing
- `python3 -m py_compile tools/sprite_to_base64.py`

------
https://chatgpt.com/codex/tasks/task_e_687d4792702083219d9152ee3784f4cd