### PR TITLE
Fix body height to prevent unnecessary scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
       min-height:100vh;
       margin:0;
       padding:1rem;
+      box-sizing:border-box;
       text-align:center;
       background-attachment:fixed;
       background-repeat:no-repeat;

--- a/login.html
+++ b/login.html
@@ -16,6 +16,7 @@
       min-height:100vh;
       margin:0;
       padding:1rem;
+      box-sizing:border-box;
       background-attachment:fixed;
       background-repeat:no-repeat;
       background-position:center;

--- a/register.html
+++ b/register.html
@@ -16,6 +16,7 @@
       min-height:100vh;
       margin:0;
       padding:1rem;
+      box-sizing:border-box;
       background-attachment:fixed;
       background-repeat:no-repeat;
       background-position:center;


### PR DESCRIPTION
## Summary
- avoid scrollbars when pages content fits by ensuring body padding doesn't extend the viewport

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687d50ab0114832196c40ec7d82989ab