### PR TITLE
Make panels transparent with thick outlines

### DIFF
--- a/design.md
+++ b/design.md
@@ -9,6 +9,9 @@ This document describes the visual design language for the application. The look
 - Rounded rectangles and beveled edges should be prominent.
 - Apply subtle gradients to create a faux-3D effect.
 - Use small, pixel-art icons for buttons and controls.
+- Windows, panes and other panels should be completely transparent with thick
+  outlines like in Winamp since sprite-based backgrounds will provide the
+  backdrop.
 - Use [98.css](https://github.com/jdan/98.css) to style tabs, buttons, and other controls, but avoid using its window components.
 
 ## Color Palette
@@ -25,7 +28,9 @@ This document describes the visual design language for the application. The look
 ## Layout Rules
 
 - Keep UI elements compact, with small padding and margins.
-- Group related controls into window-like panels with thin borders.
+- Group related controls into window-like panels. These panels should have
+  completely transparent backgrounds and thick outlines reminiscent of Winamp
+  skins, since backgrounds will always be sprite based.
 - Navigation should appear as a set of small tabs or buttons styled with the same pixel-art look.
 - Ensure the layout scales well on mobile devices so the interface remains usable on small screens.
 

--- a/index.html
+++ b/index.html
@@ -35,16 +35,25 @@
       margin:0.5rem;
       padding:0.5rem 1rem;
     }
+    .panel {
+      background:transparent;
+      border:3px solid #0ff;
+      padding:1rem;
+      width:90%;
+      max-width:300px;
+    }
     @media(min-width:600px){
       h1{font-size:1.5rem;}
     }
   </style>
 </head>
 <body>
-  <h1>Cybermmo</h1>
-  <p>Welcome to Cybermmo!</p>
-  <a href="login.html"><button class="btn">Login</button></a>
-  <a href="register.html"><button class="btn">Register</button></a>
+  <div class="panel">
+    <h1>Cybermmo</h1>
+    <p>Welcome to Cybermmo!</p>
+    <a href="login.html"><button class="btn">Login</button></a>
+    <a href="register.html"><button class="btn">Register</button></a>
+  </div>
   <script src="sprite-loader.js"></script>
   <script>
     loadBackground('Shia');

--- a/login.html
+++ b/login.html
@@ -23,8 +23,8 @@
       background-size:cover;
     }
     .panel {
-      background:rgba(17,17,17,0.8);
-      border:1px solid #444;
+      background:transparent;
+      border:3px solid #0ff;
       padding:1rem;
       width:90%;
       max-width:300px;

--- a/register.html
+++ b/register.html
@@ -23,8 +23,8 @@
       background-size:cover;
     }
     .panel {
-      background:rgba(17,17,17,0.8);
-      border:1px solid #444;
+      background:transparent;
+      border:3px solid #0ff;
       padding:1rem;
       width:90%;
       max-width:300px;


### PR DESCRIPTION
## Summary
- clarify in the design guide that all windows and panels use transparent backgrounds with thick Winamp-style outlines
- update layout rules to match this requirement
- apply new `.panel` styling to all HTML pages
- wrap the index page content in a panel

## Testing
- `python3 -m py_compile tools/sprite_to_base64.py`

------
https://chatgpt.com/codex/tasks/task_e_687d528580d883218e745566e5e37e05