### PR TITLE
Update fixed layout

### DIFF
--- a/design.md
+++ b/design.md
@@ -33,20 +33,18 @@ This document describes the visual design language for the application. The look
   skins, since backgrounds will always be sprite based.
 - Navigation should appear as a set of small tabs or buttons styled with the same pixel-art look.
 
-## Fixed Resolution Layout
+## Fixed Central Layout
 
-- Design for a base landscape resolution of **1920×1080**. All interface
-  components must be absolutely positioned within this canvas.
-- Wrap the entire UI in a single container that scales uniformly using
-  `transform: scale(...)` based on the user's viewport while preserving the
-  16:9 aspect ratio. This keeps sprite edges crisp and maintains consistent
-  alignment.
-- Responsive techniques such as flexbox, grid or media queries should not be
-  used. Positioning is deterministic to ensure pixel-perfect rendering, much
-  like classic Winamp skins or early web games such as Travian.
-- An optional portrait variant may be provided at **1080×1920** if required.
-- This approach favors clarity and determinism, making it straightforward to
-  achieve exact visual alignment of sprite-based assets.
+- Design for a base resolution of **900×600–720**. The active UI occupies this
+  fixed-size area and is centered horizontally within the viewport.
+- Do not scale the UI. All components are absolutely positioned to maintain
+  pixel-perfect alignment using sprite-based assets.
+- The outer frame (unused side margins) should display neutral or thematic
+  background visuals—such as textures or ambient illustrations—to fill the
+  remaining screen width.
+- Responsive techniques like flexbox, grid, or scaling transforms should not be
+  used. This static layout mirrors early 2000s browser games like Travian or
+  Urban Rivals, ensuring consistent visuals across displays.
 
 ## Sprites
 


### PR DESCRIPTION
## Summary
- document the new fixed central layout (900×600–720) and centering approach

## Testing
- `python3 -m py_compile tools/sprite_to_base64.py`


------
https://chatgpt.com/codex/tasks/task_e_687d5f8ad4e88321a974568c59946863