### PR TITLE
Apply fixed layout from design document

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,14 +15,15 @@
     }
     #viewport {
       position: absolute;
-      width: 1920px;
-      height: 1080px;
-      transform-origin: top left;
+      width: 900px;
+      height: 720px;
+      left: 50%;
+      transform: translateX(-50%);
     }
     .panel {
       position: absolute;
-      top: 400px;
-      left: 760px;
+      top: 200px;
+      left: 250px;
       width: 400px;
       padding: 1rem;
       background: transparent;
@@ -58,13 +59,6 @@
   <img id="bg-sprite" alt="" />
   <script src="sprite-loader.js"></script>
   <script>
-    const viewport = document.getElementById('viewport');
-    function scaleUI() {
-      const scale = Math.min(window.innerWidth / 1920, window.innerHeight / 1080);
-      viewport.style.transform = `scale(${scale})`;
-    }
-    window.addEventListener('resize', scaleUI);
-    scaleUI();
     const bg = document.getElementById('bg-sprite');
     bg.style.position = 'fixed';
     bg.style.left = 0;

--- a/login.html
+++ b/login.html
@@ -15,14 +15,15 @@
     }
     #viewport {
       position: absolute;
-      width: 1920px;
-      height: 1080px;
-      transform-origin: top left;
+      width: 900px;
+      height: 720px;
+      left: 50%;
+      transform: translateX(-50%);
     }
     .panel {
       position: absolute;
-      top: 360px;
-      left: 760px;
+      top: 200px;
+      left: 250px;
       width: 400px;
       padding: 1rem;
       background: transparent;
@@ -66,13 +67,6 @@
   <img id="bg-sprite" alt="" />
   <script src="sprite-loader.js"></script>
   <script>
-    const viewport = document.getElementById('viewport');
-    function scaleUI() {
-      const scale = Math.min(window.innerWidth / 1920, window.innerHeight / 1080);
-      viewport.style.transform = `scale(${scale})`;
-    }
-    window.addEventListener('resize', scaleUI);
-    scaleUI();
     const bg = document.getElementById('bg-sprite');
     bg.style.position = 'fixed';
     bg.style.left = 0;

--- a/register.html
+++ b/register.html
@@ -15,14 +15,15 @@
     }
     #viewport {
       position: absolute;
-      width: 1920px;
-      height: 1080px;
-      transform-origin: top left;
+      width: 900px;
+      height: 720px;
+      left: 50%;
+      transform: translateX(-50%);
     }
     .panel {
       position: absolute;
-      top: 340px;
-      left: 760px;
+      top: 200px;
+      left: 250px;
       width: 400px;
       padding: 1rem;
       background: transparent;
@@ -68,13 +69,6 @@
   <img id="bg-sprite" alt="" />
   <script src="sprite-loader.js"></script>
   <script>
-    const viewport = document.getElementById('viewport');
-    function scaleUI() {
-      const scale = Math.min(window.innerWidth / 1920, window.innerHeight / 1080);
-      viewport.style.transform = `scale(${scale})`;
-    }
-    window.addEventListener('resize', scaleUI);
-    scaleUI();
     const bg = document.getElementById('bg-sprite');
     bg.style.position = 'fixed';
     bg.style.left = 0;


### PR DESCRIPTION
## Summary
- follow design document to use fixed 900×720 viewport
- drop scaling transform logic from all pages
- center the viewport and panels using absolute positioning

## Testing
- `python3 -m py_compile tools/sprite_to_base64.py`

------
https://chatgpt.com/codex/tasks/task_e_687d60a5c9448321843f9c8febecffed