### PR TITLE
Fix sprite alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,14 +60,20 @@
   <img id="bg-sprite" alt="" />
   <script src="sprite-loader.js"></script>
   <script>
+    const viewport = document.getElementById('viewport');
     const bg = document.getElementById('bg-sprite');
+    function positionSprite() {
+      const bottomOffset = window.innerHeight - (viewport.offsetTop + viewport.offsetHeight);
+      bg.style.bottom = bottomOffset + 'px';
+    }
     bg.style.position = 'fixed';
     bg.style.left = 0;
-    bg.style.bottom = 0;
     bg.style.height = '100vh';
     bg.style.width = 'auto';
     bg.style.pointerEvents = 'none';
     bg.style.zIndex = '-1';
+    positionSprite();
+    window.addEventListener('resize', positionSprite);
     loadSprite('Shia', bg);
   </script>
 </body>

--- a/login.html
+++ b/login.html
@@ -68,14 +68,20 @@
   <img id="bg-sprite" alt="" />
   <script src="sprite-loader.js"></script>
   <script>
+    const viewport = document.getElementById('viewport');
     const bg = document.getElementById('bg-sprite');
+    function positionSprite() {
+      const bottomOffset = window.innerHeight - (viewport.offsetTop + viewport.offsetHeight);
+      bg.style.bottom = bottomOffset + 'px';
+    }
     bg.style.position = 'fixed';
     bg.style.left = 0;
-    bg.style.bottom = 0;
     bg.style.height = '100vh';
     bg.style.width = 'auto';
     bg.style.pointerEvents = 'none';
     bg.style.zIndex = '-1';
+    positionSprite();
+    window.addEventListener('resize', positionSprite);
     loadSprite('Shia', bg);
   </script>
 </body>

--- a/register.html
+++ b/register.html
@@ -70,14 +70,20 @@
   <img id="bg-sprite" alt="" />
   <script src="sprite-loader.js"></script>
   <script>
+    const viewport = document.getElementById('viewport');
     const bg = document.getElementById('bg-sprite');
+    function positionSprite() {
+      const bottomOffset = window.innerHeight - (viewport.offsetTop + viewport.offsetHeight);
+      bg.style.bottom = bottomOffset + 'px';
+    }
     bg.style.position = 'fixed';
     bg.style.left = 0;
-    bg.style.bottom = 0;
     bg.style.height = '100vh';
     bg.style.width = 'auto';
     bg.style.pointerEvents = 'none';
     bg.style.zIndex = '-1';
+    positionSprite();
+    window.addEventListener('resize', positionSprite);
     loadSprite('Shia', bg);
   </script>
 </body>


### PR DESCRIPTION
## Summary
- keep the 900‑px viewport centered
- align the background sprite with the bottom of the viewport

## Testing
- `apt-get update`
- `apt-get install -y imagemagick`


------
https://chatgpt.com/codex/tasks/task_e_687d634c69bc83218b9a5b271abc80a6