### PR TITLE
Fix mobile scroll and update doc

### DIFF
--- a/design.md
+++ b/design.md
@@ -37,8 +37,11 @@ This document describes the visual design language for the application. The look
 
 - Design for a base resolution of **900×600–720**. The active UI occupies this
   fixed-size area and is centered horizontally within the viewport.
-- Do not scale the UI. All components are absolutely positioned to maintain
-  pixel-perfect alignment using sprite-based assets.
+- Do not scale the UI. All components should be positioned with fixed pixel
+  values to maintain sprite alignment. The main viewport element itself should
+  remain in normal document flow (not absolutely positioned) so the page width
+  expands to the full 900px. This ensures horizontal scrolling works correctly
+  on narrow displays.
 - The outer frame (unused side margins) should display neutral or thematic background visuals—such as textures or ambient illustrations—to fill the remaining screen width.
 - Responsive techniques like flexbox, grid, or scaling transforms should not be used. This static layout mirrors early 2000s browser games like Travian or Urban Rivals, ensuring consistent visuals across displays.
 - On small screens, horizontal scrolling is acceptable; the layout must remain at native scale.

--- a/style.css
+++ b/style.css
@@ -1,17 +1,16 @@
 body {
   margin: 0;
   overflow-x: auto;
-  overflow-y: hidden;
+  overflow-y: auto;
   background: #222;
   color: #0ff;
   font-family: 'Pixelated MS Sans Serif', 'MS Sans Serif', Tahoma, sans-serif;
 }
 #viewport {
-  position: absolute;
+  position: relative;
   width: 900px;
   height: 720px;
-  left: 50%;
-  transform: translateX(-50%);
+  margin: 0 auto;
   background: #000;
 }
 .panel {


### PR DESCRIPTION
## Summary
- allow vertical scrolling and center viewport without absolute positioning
- clarify layout rules in the design guide

## Testing
- `python3 -m py_compile tools/sprite_to_base64.py`


------
https://chatgpt.com/codex/tasks/task_e_687d68ce6700832180472c067ffffa33