### PR TITLE
Add simple border overlay component

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,19 +8,18 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div id="viewport">
-      <div class="panel-wrapper">
-      <div class="panel-bg"></div>
-      <div class="panel-content">
-        <h1>Cybermmo</h1>
-        <p>Welcome to Cybermmo!</p>
-        <div class="center">
-          <a href="login.html"><button class="btn">Login</button></a>
-          <a href="register.html"><button class="btn">Register</button></a>
-        </div>
+  <div id="viewport">
+    <img id="bg-sprite" alt="" />
+    <div class="panel">
+      <h1>Cybermmo</h1>
+      <p>Welcome to Cybermmo!</p>
+      <div class="center">
+        <a href="login.html"><button class="btn">Login</button></a>
+        <a href="register.html"><button class="btn">Register</button></a>
       </div>
     </div>
-    </div>
+    <simple-border target=".panel"></simple-border>
+  </div>
   <script src="script.js"></script>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -9,9 +9,8 @@
 </head>
 <body>
   <div id="viewport">
-    <div class="panel panel-bg"></div>
     <img id="bg-sprite" alt="" />
-    <div class="panel panel-content">
+    <div class="panel">
       <h2 class="center">Login</h2>
       <form>
         <label for="username">Username</label>
@@ -24,6 +23,7 @@
         <p class="center"><a href="register.html">Register</a></p>
       </form>
     </div>
+    <simple-border target=".panel"></simple-border>
   </div>
   <script src="script.js"></script>
 </body>

--- a/register.html
+++ b/register.html
@@ -9,9 +9,8 @@
 </head>
 <body>
   <div id="viewport">
-    <div class="panel panel-bg"></div>
     <img id="bg-sprite" alt="" />
-    <div class="panel panel-content">
+    <div class="panel">
       <h2 class="center">Register</h2>
       <form>
         <label for="username">Username</label>
@@ -26,6 +25,7 @@
         <p class="center"><a href="login.html">Login</a></p>
       </form>
     </div>
+    <simple-border target=".panel"></simple-border>
   </div>
   <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -49,5 +49,29 @@ async function loadBackground(name, element = document.body) {
   }
 }
 
+// Simple border overlay component
+class SimpleBorder extends HTMLElement {
+  connectedCallback() {
+    const selector = this.getAttribute('target');
+    const zIndex = this.getAttribute('z-index') || '10';
+    const target = document.querySelector(selector);
+    if (!target) return;
+
+    const rect = target.getBoundingClientRect();
+    const style = this.style;
+
+    style.position = 'absolute';
+    style.top = `${rect.top}px`;
+    style.left = `${rect.left}px`;
+    style.width = `${rect.width}px`;
+    style.height = `${rect.height}px`;
+    style.border = '2px solid red';
+    style.pointerEvents = 'none';
+    style.zIndex = zIndex;
+  }
+}
+
+customElements.define('simple-border', SimpleBorder);
+
 // Example usage (you can remove this line from the file if not needed)
 renderSprite('Shia', 0, 0, 20);

--- a/style.css
+++ b/style.css
@@ -24,7 +24,6 @@ body {
   z-index: 20;
 }
 
-/*
 .panel {
   position: absolute;
   top: 50%;
@@ -35,81 +34,49 @@ body {
   background: transparent;
   border: 3px solid #0ff;
   border-radius: 6px;
-}
-
-.panel-bg {
   z-index: 10;
 }
 
-.panel-content {
-  z-index: 30;
-}*/
-
-.panel-wrapper {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 400px;
-  height: auto;
-}
-
-.panel-bg {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  padding: 1rem;
-  box-sizing: border-box;
-  border: 3px solid #0ff;
-  border-radius: 6px;
-  background: transparent;
-  z-index: 10;
-}
-
-.panel-content {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  padding: 1rem;
-  box-sizing: border-box;
-  border-radius: 6px;
-  background: transparent;
+/* Panel children should appear above sprites */
+.panel > * {
+  position: relative;
   z-index: 30;
 }
 
-/* Panel content should appear above sprites via its z-index */
 .btn {
   margin: 0.5rem;
   padding: 0.75rem 1.5rem;
   font-size: 1.25rem;
 }
+
 h1 {
   margin-bottom: 1rem;
   font-size: 1.75rem;
   text-align: center;
 }
+
 p {
   margin-bottom: 1.5rem;
   text-align: center;
   font-size: 1.25rem;
 }
+
 label,
 input {
   display: block;
   width: 100%;
   margin-bottom: 0.5rem;
 }
+
 .center {
   text-align: center;
 }
+
 h2 {
   font-size: 1.75rem;
   margin-bottom: 1rem;
 }
+
 label,
 input,
 button {


### PR DESCRIPTION
## Summary
- revert pages back to single panel layout
- restore original panel CSS
- implement `simple-border` custom element
- draw border on each panel via `<simple-border>`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687e1e342254832180e3bc47a473976c