### PR TITLE
Add customizable border to simple-border

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
         <a href="register.html"><button class="btn">Register</button></a>
       </div>
     </div>
-    <simple-border target=".panel"></simple-border>
+    <simple-border target=".panel" border="3px solid #0ff" border-radius="6px"></simple-border>
   </div>
   <script src="script.js"></script>
 </body>

--- a/login.html
+++ b/login.html
@@ -23,7 +23,7 @@
         <p class="center"><a href="register.html">Register</a></p>
       </form>
     </div>
-    <simple-border target=".panel"></simple-border>
+    <simple-border target=".panel" border="3px solid #0ff" border-radius="6px"></simple-border>
   </div>
   <script src="script.js"></script>
 </body>

--- a/register.html
+++ b/register.html
@@ -25,7 +25,7 @@
         <p class="center"><a href="login.html">Login</a></p>
       </form>
     </div>
-    <simple-border target=".panel"></simple-border>
+    <simple-border target=".panel" border="3px solid #0ff" border-radius="6px"></simple-border>
   </div>
   <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -60,12 +60,16 @@ class SimpleBorder extends HTMLElement {
     const rect = target.getBoundingClientRect();
     const style = this.style;
 
+    const border = this.getAttribute('border') || '2px solid red';
+    const borderRadius = this.getAttribute('border-radius') || '0';
+
     style.position = 'absolute';
     style.top = `${rect.top}px`;
     style.left = `${rect.left}px`;
     style.width = `${rect.width}px`;
     style.height = `${rect.height}px`;
-    style.border = '2px solid red';
+    style.border = border;
+    style.borderRadius = borderRadius;
     style.pointerEvents = 'none';
     style.zIndex = zIndex;
   }


### PR DESCRIPTION
## Summary
- accept `border` and `border-radius` attributes in `simple-border`
- apply neon border on all pages using the new attributes

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_687e224c91d08321ab9ec5c08ed6577e