### PR TITLE
Fix simple border alignment

### DIFF
--- a/script.js
+++ b/script.js
@@ -70,6 +70,7 @@ class SimpleBorder extends HTMLElement {
     style.left = `${rect.left - parentRect.left}px`;
     style.width = `${rect.width}px`;
     style.height = `${rect.height}px`;
+    style.boxSizing = 'border-box';
     style.border = border;
     style.borderRadius = borderRadius;
     style.pointerEvents = 'none';


### PR DESCRIPTION
## Summary
- apply `box-sizing: border-box` to the custom `simple-border` overlay so the border width is accounted for

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687e2f5d21688321b52d26def29ca8b3