### PR TITLE
Add Richie and Bakuto to righthand selection

### DIFF
--- a/selectrighthand.html
+++ b/selectrighthand.html
@@ -29,24 +29,14 @@
           <input type="radio" name="righthand" value="Shia" data-sprite="Shia" checked>
         </label>
         <label class="thumb">
-          <img alt="Nova">
-          <span>Nova</span>
-          <input type="radio" name="righthand" value="Nova" data-sprite="Shia">
+          <img alt="Richie">
+          <span>Richie</span>
+          <input type="radio" name="righthand" value="Richie" data-sprite="richie">
         </label>
         <label class="thumb">
-          <img alt="Zero">
-          <span>Zero</span>
-          <input type="radio" name="righthand" value="Zero" data-sprite="shia-toonified">
-        </label>
-        <label class="thumb">
-          <img alt="Echo">
-          <span>Echo</span>
-          <input type="radio" name="righthand" value="Echo" data-sprite="Shia">
-        </label>
-        <label class="thumb">
-          <img alt="Deno">
-          <span>Deno</span>
-          <input type="radio" name="righthand" value="Deno" data-sprite="shia-denoised">
+          <img alt="Bakuto">
+          <span>Bakuto</span>
+          <input type="radio" name="righthand" value="Bakuto" data-sprite="bakuto">
         </label>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove placeholder characters from the right hand selection screen
- add Richie and Bakuto as options alongside Shia

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f76193dec832188a40db1d62c7598