### PR TITLE
Improve resize tool downscaling quality

### DIFF
--- a/tools.md
+++ b/tools.md
@@ -58,7 +58,8 @@ As with the other tools, omit `input.txt` to read from stdin or omit
 
 ## `base64_resize.py`
 
-Resizes a Base64 sprite to the given width and height.
+Resizes a Base64 sprite to the given width and height. When shrinking an image
+the script automatically uses a high-quality Lanczos filter to reduce aliasing.
 
 ### Usage
 

--- a/tools/base64_resize.py
+++ b/tools/base64_resize.py
@@ -37,7 +37,13 @@ def main() -> None:
     img_bytes = read_base64(args.input)
     img = Image.open(BytesIO(img_bytes))
 
-    resized = img.resize((args.width, args.height), Image.NEAREST)
+    # Use high-quality resampling when shrinking to avoid aliasing artifacts.
+    if args.width < img.width or args.height < img.height:
+        resample = Image.LANCZOS
+    else:
+        resample = Image.NEAREST
+
+    resized = img.resize((args.width, args.height), resample)
 
     buf = BytesIO()
     resized.save(buf, format="PNG")


### PR DESCRIPTION
## Summary
- improve `base64_resize.py` by using Lanczos when shrinking images
- document the higher quality downscaling in `tools.md`

## Testing
- `python3 -m py_compile tools/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880e00111208321ad547b020d4f3e5d